### PR TITLE
enlarge initial budgets in production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-
 # RitminFrontend
 
 This project was generated using [Nx](https://nx.dev).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # RitminFrontend
 
 This project was generated using [Nx](https://nx.dev).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RitminFrontend
+# RitminFrontend 
 
 This project was generated using [Nx](https://nx.dev).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RitminFrontend 
+# RitminFrontend
 
 This project was generated using [Nx](https://nx.dev).
 

--- a/angular.json
+++ b/angular.json
@@ -37,8 +37,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "1mb",
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
```
22:32:55.356	Executing user command: ng build
22:32:55.734	
22:32:55.735	> nx run nekohit:build:production 
22:32:57.891	- Generating browser application bundles (phase: setup)...
22:33:35.684	✔ Browser application bundle generation complete.
22:33:35.702	✔ Browser application bundle generation complete.
22:33:35.709	
22:33:35.709	Initial Chunk Files               | Names         |      Size
22:33:35.709	main.7e056d9936a35d0b9d6a.js      | main          | 668.15 kB
22:33:35.709	styles.b2609dd3bcd21e8e9186.css   | styles        | 359.72 kB
22:33:35.709	scripts.9e353e1e67f302d922c7.js   | scripts       | 182.92 kB
22:33:35.709	polyfills.6f79331f4bfa584ba7d9.js | polyfills     |  35.98 kB
22:33:35.709	runtime.0caa16a0a2084e0dd5db.js   | runtime       |   1.01 kB
22:33:35.709	
22:33:35.709	| Initial Total |   1.22 MB
22:33:35.709	
22:33:35.709	Build at: 2021-09-10T14:33:35.707Z - Hash: d0248414431ade0cfe84 - Time: 36375ms
22:33:35.711	
22:33:35.711	Warning: initial exceeded maximum budget. Budget 500.00 kB was not met by 747.78 kB with a total of 1.22 MB.
22:33:35.711	
22:33:35.711	
22:33:35.711	
22:33:35.711	Error: initial exceeded maximum budget. Budget 1.00 MB was not met by 223.78 kB with a total of 1.22 MB.
22:33:35.711	
22:33:35.712	
22:33:35.750	
22:33:35.750	———————————————————————————————————————————————
22:33:35.751	
22:33:35.751	>  NX   ERROR  Running target "nekohit:build" failed
22:33:35.751	
22:33:35.751	  Failed tasks:
22:33:35.752	  
22:33:35.752	  - nekohit:build:production
22:33:35.752	  
22:33:35.752	  Hint: run the command with --verbose for more details.
22:33:35.752	
22:33:35.764	Failed: build command exited with code: 1
```

The initial budgets trigger the error and failed the build. Set it to `2mb` will fix the build.